### PR TITLE
[FEAT] 표류병의 공개 여부를 반환하는 기능 구현

### DIFF
--- a/src/main/java/com/hackathon/org/common/status/ErrorStatus.java
+++ b/src/main/java/com/hackathon/org/common/status/ErrorStatus.java
@@ -9,13 +9,21 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorStatus {
 
+    /**
+     * 500
+     */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러"),
+    FAIL_TO_REGISTER(HttpStatus.INTERNAL_SERVER_ERROR, "등록 실패"),
+    INVALID_DATE_DIFFERENCE(HttpStatus.INTERNAL_SERVER_ERROR, "잘못된 날짜 정보"),
 
+
+    /**
+     * 404
+     */
     NOT_FOUND(HttpStatus.NOT_FOUND, "잘못된 요청"),
-
     INVALID_ID(HttpStatus.NOT_FOUND, "잘못된 id 정보"),
 
-    FAILE_TO_REGISTER(HttpStatus.INTERNAL_SERVER_ERROR, "등록 실패"),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/hackathon/org/controller/PostController.java
+++ b/src/main/java/com/hackathon/org/controller/PostController.java
@@ -6,12 +6,7 @@ import com.hackathon.org.controller.dto.PostListResponseDto;
 import com.hackathon.org.controller.dto.PostRegisterDto;
 import com.hackathon.org.service.PostService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/hackathon/org/controller/dto/RoomResponseDto.java
+++ b/src/main/java/com/hackathon/org/controller/dto/RoomResponseDto.java
@@ -14,14 +14,14 @@ import lombok.Getter;
 public class RoomResponseDto {
     private Long roomId;
     private boolean isPublic;
-    private int remainingDays;
+    private long remainingDays;
     private int remainingCode;
 
     public static RoomResponseDto of(Room room) {
-        int dateDifference = RoomUtil.calculateDateDifference(room.getCreatedAt());
-        return RoomResponseDto.builder().roomId(room.getRoomId()).isPublic(room.getIsPublic())
+        long dateDifference = RoomUtil.calculateDateDifference(room.getCreatedAt());
+        return RoomResponseDto.builder().roomId(room.getRoomId()).isPublic(dateDifference <= 0)
                 .remainingDays(dateDifference)
-                .remainingCode(RemainingCode.getRemainingCodeNumberWithDateDifference(dateDifference)).build();
+                .remainingCode(RemainingCode.getRemainingCodeNumber(dateDifference)).build();
 
     }
 }

--- a/src/main/java/com/hackathon/org/domain/RemainingCode.java
+++ b/src/main/java/com/hackathon/org/domain/RemainingCode.java
@@ -1,11 +1,13 @@
 package com.hackathon.org.domain;
 
-import static com.hackathon.org.common.status.ErrorStatus.NOT_FOUND;
-
 import com.hackathon.org.common.error.model.NotFoundException;
-import java.util.Arrays;
+import com.hackathon.org.utils.RoomUtil;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+import static com.hackathon.org.common.status.ErrorStatus.INVALID_DATE_DIFFERENCE;
 
 @Getter
 @RequiredArgsConstructor
@@ -17,24 +19,13 @@ public enum RemainingCode {
     private final int minDifferenceRange;
     private final int maxDifferenceRange;
 
-    private static final int EXPIRATION_DATE_MAX_RANGE = 7;
-    private static final int EXPIRATION_DATE_MIN_RANGE = 0;
-
-    // TODO : 추후 예외처리
-    private static RemainingCode getRemainingCodeWithDateDifference(final int dateDifference) {
+    private static RemainingCode getRemainingCodeWithDateDifference(final long dateDifference) {
         return Arrays.stream(values())
                 .filter(v -> v.maxDifferenceRange == dateDifference || v.minDifferenceRange == dateDifference)
-                .findFirst().orElseThrow(() -> new NotFoundException(NOT_FOUND));
+                .findFirst().orElseThrow(() -> new NotFoundException(INVALID_DATE_DIFFERENCE));
     }
 
-    private static int clamp(int dateDifference) {
-        if (dateDifference > EXPIRATION_DATE_MAX_RANGE) {
-            return EXPIRATION_DATE_MAX_RANGE;
-        }
-        return Math.max(dateDifference, EXPIRATION_DATE_MIN_RANGE);
-    }
-
-    public static int getRemainingCodeNumberWithDateDifference(final int dateDifference) {
-        return getRemainingCodeWithDateDifference(clamp(dateDifference)).getRemainingCodeNumber();
+    public static int getRemainingCodeNumber(final long dateDifference) {
+        return getRemainingCodeWithDateDifference(RoomUtil.clampDateRange(dateDifference)).getRemainingCodeNumber();
     }
 }

--- a/src/main/java/com/hackathon/org/domain/Room.java
+++ b/src/main/java/com/hackathon/org/domain/Room.java
@@ -1,16 +1,10 @@
 package com.hackathon.org.domain;
 
-import java.time.LocalDate;
-import javax.persistence.*;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import net.bytebuddy.implementation.bind.annotation.Default;
-import org.hibernate.annotations.ColumnDefault;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.*;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -28,11 +22,4 @@ public class Room {
 
     @CreatedDate
     private LocalDate createdAt;
-
-    @ColumnDefault("false")
-    private boolean isPublic;
-
-    public boolean getIsPublic() {
-        return isPublic;
-    }
 }

--- a/src/main/java/com/hackathon/org/utils/RoomUtil.java
+++ b/src/main/java/com/hackathon/org/utils/RoomUtil.java
@@ -4,12 +4,21 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 
 public class RoomUtil {
+    private static final int EXPIRATION_PERIOD = 7;
+    private static final int DATE_DIFFERENCE_MIN_RANGE = 0;
 
-    private static final int EXPIRED_DURATION = 7;
+    public static long calculateDateDifference(LocalDate createdAt) {
+        return ChronoUnit.DAYS.between(LocalDate.now(),
+                createdAt.plus(EXPIRATION_PERIOD, ChronoUnit.DAYS));
+    }
 
-    public static int calculateDateDifference(LocalDate createdAt) {
-        int dateDifference = (int) ChronoUnit.DAYS.between(LocalDate.now(),
-                createdAt.plus(EXPIRED_DURATION, ChronoUnit.DAYS));
-        return Math.max(dateDifference, 0);
+    public static long clampDateRange(long dateDifference) {
+        if (dateDifference > EXPIRATION_PERIOD) {
+            return EXPIRATION_PERIOD;
+        }
+        if (dateDifference < DATE_DIFFERENCE_MIN_RANGE) {
+            return DATE_DIFFERENCE_MIN_RANGE;
+        }
+        return dateDifference;
     }
 }


### PR DESCRIPTION

## 관련이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
- Resolved: #13 

## 변경사항
- 기존 로직
   - 도메인에 isPublic 을 저장하고, 스케줄러가 매일 정각마다 확인해서 공개여부를 저장
- 변경된 로직
   - 표류병 목록 조회 요청 시 Room 이 생성된 일자로부터 7일이 지났는지 확인해서 반환
